### PR TITLE
Don't overwrite mimetype

### DIFF
--- a/lib/Model/IMAPMessage.php
+++ b/lib/Model/IMAPMessage.php
@@ -540,11 +540,6 @@ class IMAPMessage implements IMessage, JsonSerializable {
 			throw new DoesNotExistException("Mail body for this mail($this->messageId) could not be loaded");
 		}
 
-		$mimeHeaders = $fetch->getMimeHeader($partNo, Horde_Imap_Client_Data_Fetch::HEADER_PARSE);
-		if ($enc = $mimeHeaders->getValue('content-transfer-encoding')) {
-			$p->setTransferEncoding($enc);
-		}
-
 		$data = $fetch->getBodyPart($partNo);
 
 		$p->setContents($data);


### PR DESCRIPTION
This breaks the formatting of some emails from GitLab.

Before this change, the message contains quoted-printable characters and the links are broken:
![nextcloud_mail_patch_before](https://user-images.githubusercontent.com/1885159/50090176-119ce680-0208-11e9-891a-dd527fd8e7f5.png)

After, the message is correctly interpreted and the links are fixed:
![nextcloud_mail_patch_after](https://user-images.githubusercontent.com/1885159/50090217-2ed1b500-0208-11e9-8397-b3e8cacdca96.png)

I have not seen this change break the formatting of any other emails in my inbox, only fix them.